### PR TITLE
Load faster, remove annoying extra popup/dead shop

### DIFF
--- a/tinfoilshop.json
+++ b/tinfoilshop.json
@@ -1,4 +1,3 @@
 {
-    "locations": ["https://quotanx.in", "https://nekoshop.cf", "https://stealthshop.cf", "https://redump.cf", "https://titz.cf", "https://tinfoilhost.voxhost.fr/"],
-    "success": "歡迎使用carcaschoi黑商店萬能服務器\n即使商店連結更新，也不需要再手動輸入了，省時省心 :)\n\n我的Youtube頻道: carcaschoi ，歡迎訂閱！\n\nWelcome to Ultimate Freeshop which is maintained by carcaschoi\n\nIt redirects to all of the alternative shops so you don't need to add shop manually if the shop link is updated\n\nSource:\nhttps://github.com/carcaschoi/tinfoil-json"
+    "locations": ["https://quotanx.in", "https://nekoshop.cf", "https://stealthshop.cf", "https://titz.cf", "https://tinfoilhost.voxhost.fr/"]
 }


### PR DESCRIPTION
prevent tinfoil from being slow from too many popup, also remove redump as hasn't been updated in months and most links are dead from gdrive edu death, or is serving old update files.